### PR TITLE
rename the Logger object and method type names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,12 @@ const ansi = new RegExp(
 
 export const stripAnsi = (input: string) => input.replace(ansi, "");
 
-export type LogFunc = (
+export type LogMethod = (
     ...input: (string | object | object[] | unknown)[]
 ) => void;
 
-export type LogFunction<K extends string> = {
-    [a in K]: LogFunc;
+export type Logger<K extends string> = {
+    [a in K]: LogMethod;
 };
 
 export type PadType = "PREPEND" | "APPEND";
@@ -147,5 +147,5 @@ export const createLogger = <A extends string>(
                 },
             };
         })
-    ) as LogFunction<A>;
+    ) as Logger<A>;
 };

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,10 +1,10 @@
 import chalk from "chalk";
-import { createLogger, LogFunction } from "../src";
+import { createLogger, Logger } from "../src";
 
 const logFn = jest.fn();
 
 describe("Basic Logging", () => {
-    let logger: LogFunction<"ok">;
+    let logger: Logger<"ok">;
 
     beforeAll(() => {
         logger = createLogger(
@@ -40,7 +40,7 @@ describe("Basic Logging", () => {
 });
 
 describe("Objects & Arrays", () => {
-    let logger: LogFunction<"ok">;
+    let logger: Logger<"ok">;
 
     beforeAll(() => {
         logger = createLogger(
@@ -68,8 +68,8 @@ describe("Objects & Arrays", () => {
 });
 
 describe("Prepend vs Append", () => {
-    let loggerPrepend: LogFunction<"short" | "longer">;
-    let loggerAppend: LogFunction<"short" | "longer">;
+    let loggerPrepend: Logger<"short" | "longer">;
+    let loggerAppend: Logger<"short" | "longer">;
 
     beforeAll(() => {
         loggerPrepend = createLogger(
@@ -105,7 +105,7 @@ describe("Prepend vs Append", () => {
 });
 
 describe("Multiline Wrapping", () => {
-    let logger: LogFunction<"plaintext" | "oneline" | "twoline">;
+    let logger: Logger<"plaintext" | "oneline" | "twoline">;
 
     beforeAll(() => {
         logger = createLogger(
@@ -145,7 +145,7 @@ describe("Multiline Wrapping", () => {
 
 describe("Default values", () => {
     let consoleLog: jest.SpyInstance;
-    let logger: LogFunction<"default">;
+    let logger: Logger<"default">;
 
     beforeAll(() => {
         consoleLog = jest.spyOn(console, "log").mockImplementation(() => {});


### PR DESCRIPTION
rename `LogFun` to `LogMethod` and `LogFunction` to `Logger` to make the purpose of the objects clearer 